### PR TITLE
Fix an issue when fix a bad link

### DIFF
--- a/library/WEM/Location/Module/Core.php
+++ b/library/WEM/Location/Module/Core.php
@@ -128,7 +128,7 @@ abstract class Core extends \Module
             $arrItem["address"] = $arrItem["street"]." ".$arrItem["postal"]." ".$arrItem["city"];
 
             // Format website (we assume that every url is an external one)
-            if ($arrItem["website"] && "http" != substr($arrItem["website"], 4)) {
+            if ($arrItem["website"] && "http" != substr($arrItem["website"], 0, 4)) {
                 $arrItem["website"] = "http://".$arrItem["website"];
             }
 


### PR DESCRIPTION
- When a link does not include an http, the module will automaticly add it. The test to check was wrong and is fixed now.